### PR TITLE
U package.json: fix build warnings: about Using / for division outsid… #55

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
     "cross-env": "^7.0.3",
     "fs-extra": "^11.2.0",
     "glob": "^11.0.0",
-    "sass": "~1.79.5",
+    "sass": "~1.32.12",
     "sass-loader": "^10.5.2",
     "typeface-roboto": "^1.1.13",
     "vue-cli-plugin-vuetify": "^2.5.8",


### PR DESCRIPTION
…e of calc() is deprecated